### PR TITLE
Fix tree layout, tooltip render times display, and panel dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ As an open-sourced project, ReactMonitor gladly accepts help whenever possible. 
 
 ## Authors
 
-Rudo Hengst: [@RudoH](https://github.com/RudoH)\
-Lia Pham:    [@lpham598](https://github.com/lpham598)\
-Tommy Han:   [@simple-sifu](https://github.com/simple-sifu)
+**Rudo Hengst:** [@RudoH](https://github.com/RudoH)\
+**Lia Pham:**    [@lpham598](https://github.com/lpham598)\
+**Tommy Han:**   [@simple-sifu](https://github.com/simple-sifu)
 
 ## License 
 

--- a/src/app/components/d3tree.js
+++ b/src/app/components/d3tree.js
@@ -81,7 +81,7 @@ export default class D3Tree extends Component {
     const link = g
       .append('g')
       .attr('fill', 'none')
-      .attr('stroke', '#555')
+      .attr('stroke', '#D4CDF4')
       .attr('stroke-opacity', 0.4)
       .attr('stroke-width', 1.5)
       .selectAll('path')
@@ -163,6 +163,11 @@ export default class D3Tree extends Component {
   }
 
   render() {
-    return <div ref={this.treeRef}></div>;
+    return (
+      <div class="container" id="tree-container">
+        <h3 class="graph-title">Render Times Tree Graph</h3>
+        <div className="graphDiv" ref={this.treeRef}></div>
+      </div>
+    )
   }
 }

--- a/src/app/components/d3tree.js
+++ b/src/app/components/d3tree.js
@@ -129,7 +129,7 @@ export default class D3Tree extends Component {
                          <br><strong>Props</strong>: ${d.data.stats.props}<br>
                          <br><strong>Tag</strong>: ${d.data.tag}<br>
                          <br><strong>EffectTag</strong>: ${d.data.stats.effectTag}<br>
-                         <br><strong>Render Time</strong>: ${d.data.stats.renderTotal} seconds</p>
+                         <br><strong>Render Time</strong>: ${d.data.stats.renderTotal}ms</p>
                          `, this)
           .style('left', (d3.event.pageX) + 'px')
           .style('top', (d3.event.pageY) + 'px');

--- a/src/app/components/d3tree.js
+++ b/src/app/components/d3tree.js
@@ -129,7 +129,6 @@ export default class D3Tree extends Component {
                          <br><strong>Props</strong>: ${d.data.stats.props}<br>
                          <br><strong>Tag</strong>: ${d.data.tag}<br>
                          <br><strong>EffectTag</strong>: ${d.data.stats.effectTag}<br>
-                         <br><strong>Render Start</strong>: ${d.data.stats.renderStart} seconds<br>
                          <br><strong>Render Time</strong>: ${d.data.stats.renderTotal} seconds</p>
                          `, this)
           .style('left', (d3.event.pageX) + 'px')
@@ -164,6 +163,6 @@ export default class D3Tree extends Component {
   }
 
   render() {
-    return <div ref={this.treeRef}></div>
+    return <div ref={this.treeRef}></div>;
   }
 }

--- a/src/app/style.scss
+++ b/src/app/style.scss
@@ -1,9 +1,3 @@
-// $primary-color: #000000;
-// $secondary-color: #14213d;
-// $tertiary-color: #e5e5e5;
-// $light-color: #ffffff;
-// $other-color: #fca311;
-
 $primary-color: #7A679B;
 $secondary-color: #685155;
 $tertiary-color: #8B85C1;

--- a/src/app/style.scss
+++ b/src/app/style.scss
@@ -65,9 +65,10 @@ body {
 }
 
 .graphDiv {
-  display: block;
   margin: 0 20px; 
   padding: 0 20px;
+  width: 100%;
+  height: 100%;
 }
 
 .d3-flame-graph-tip {

--- a/src/extension/backgroundScript.js
+++ b/src/extension/backgroundScript.js
@@ -14,10 +14,6 @@ chrome.runtime.onConnect.addListener((port) => {
   });
 });
 
-// chrome.runtime.onDisconnect.addListener(() => {
-//   // remove port
-// });
-
 // listen for message from contentScript
 chrome.runtime.onMessage.addListener((msg) => {
   // reassign the treeGraph
@@ -44,9 +40,7 @@ chrome.runtime.onInstalled.addListener(() => {
 chrome.contextMenus.onClicked.addListener(({ menuItemId }) => {
   const options = {
     type: 'panel',
-    left: 0,
-    top: 0,
-    width: 380,
+    width: 960,
     height: window.screen.availHeight,
     url: chrome.runtime.getURL('index.html'),
   };


### PR DESCRIPTION
Updated the SCSS for the tree layout; colors and positioning
Removed render start from component tree tooltips, changed times to ms
Changed panel width to be wider and open on active monitor (changed left, top attr)